### PR TITLE
Move changedtick tracking into python.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -420,18 +420,6 @@ function! s:SetUpCompleteopt()
 endfunction
 
 
-" For various functions/use-cases, we want to keep track of whether the buffer
-" has changed since the last time they were invoked. We keep the state of
-" b:changedtick of the last time the specific function was called in
-" b:ycm_changedtick.
-function! s:SetUpYcmChangedTick()
-  let b:ycm_changedtick  =
-        \ get( b:, 'ycm_changedtick', {
-        \   'file_ready_to_parse' : -1,
-        \ } )
-endfunction
-
-
 function! s:OnVimLeave()
   exec s:python_command "ycm_state.OnVimLeave()"
 endfunction
@@ -456,11 +444,6 @@ endfunction
 
 
 function! s:OnBufferRead()
-  " We need to do this even when we are not allowed to complete in the current
-  " buffer because we might be allowed to complete in the future! The canonical
-  " example is creating a new buffer with :enew and then setting a filetype.
-  call s:SetUpYcmChangedTick()
-
   if !s:AllowedToCompleteInCurrentBuffer()
     return
   endif
@@ -511,21 +494,7 @@ endfunction
 
 
 function! s:OnFileReadyToParse()
-  " We need to call this just in case there is no b:ycm_changetick; this can
-  " happen for special buffers.
-  call s:SetUpYcmChangedTick()
-
-  " Order is important here; we need to extract any information before
-  " reparsing the file again. If we sent the new parse request first, then
-  " the response would always be pending when we called
-  " HandleFileParseRequest.
-  exec s:python_command "ycm_state.HandleFileParseRequest()"
-
-  let buffer_changed = b:changedtick != b:ycm_changedtick.file_ready_to_parse
-  if buffer_changed
-    exec s:python_command "ycm_state.OnFileReadyToParse()"
-  endif
-  let b:ycm_changedtick.file_ready_to_parse = b:changedtick
+  exec s:python_command "ycm_state.OnFileReadyToParse()"
 endfunction
 
 
@@ -841,8 +810,7 @@ function! s:ForceCompile()
   endif
 
   echom "Forcing compilation, this will block Vim until done."
-  exec s:python_command "ycm_state.OnFileReadyToParse()"
-  exec s:python_command "ycm_state.HandleFileParseRequest( True )"
+  exec s:python_command "ycm_state.OnFileReadyToParse( True )"
 
   return 1
 endfunction

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2016, Davit Samvelyan
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from ycm import vimsupport
+from ycm.client.event_notification import EventNotification
+
+
+class Buffer( object ):
+
+  def __init__( self, bufnr ):
+    self.number = bufnr
+    self._parse_tick = 0
+    self._handled_tick = 0
+    self._parse_request = None
+    self._diagnostics = []
+
+
+  def FileParseRequestReady( self, block = False ):
+    return self._parse_tick == 0 or block or self._parse_request.Done()
+
+
+  def SendParseRequest( self, extra_data ):
+    self._parse_request = EventNotification( 'FileReadyToParse',
+                                             extra_data = extra_data )
+    self._parse_request.Start()
+    self._parse_tick = self._ChangedTick()
+
+
+  def NeedsReparse( self ):
+    return self._parse_tick < self._ChangedTick()
+
+
+  def Diagnostics( self ):
+    return self._diagnostics
+
+
+  def UpdateDiagnostics( self ):
+    self._diagnostics = self._parse_request.Response()
+
+
+  def GetResponse( self ):
+    return self._parse_request.Response()
+
+
+  def IsResponseHandled( self ):
+    return self._handled_tick == self._parse_tick
+
+
+  def MarkResponseHandled( self ):
+    self._handled_tick = self._parse_tick
+
+
+  def _ChangedTick( self ):
+    return vimsupport.GetBufferChangeTick(self.number)
+
+
+class BufferDict( dict ):
+
+  def __missing__( self, key ):
+    value = self[ key ] = Buffer( key )
+    return value

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -25,7 +25,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.tests.test_utils import ( CurrentWorkingDirectory, ExtendedMock,
+from ycm.tests.test_utils import ( CurrentWorkingDirectory,
+                                   EmulateCurrentBufferChange, ExtendedMock,
                                    MockVimBuffers, MockVimModule, VimBuffer )
 MockVimModule()
 
@@ -112,7 +113,7 @@ def MockEventNotification( response_method, native_filetype_completer = True ):
 def EventNotification_FileReadyToParse_NonDiagnostic_Error_test(
     ycm, post_vim_message ):
 
-  # This test validates the behaviour of YouCompleteMe.HandleFileParseRequest
+  # This test validates the behaviour of YouCompleteMe.HandleFileParseResponse
   # in combination with YouCompleteMe.OnFileReadyToParse when the completer
   # raises an exception handling FileReadyToParse event notification
   ERROR_TEXT = 'Some completer response text'
@@ -124,7 +125,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_test(
     with MockEventNotification( ErrorResponse ):
       ycm.OnFileReadyToParse()
       ok_( ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
+      ycm.HandleFileParseResponse()
 
       # The first call raises a warning
       post_vim_message.assert_has_exact_calls( [
@@ -132,15 +133,16 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_test(
       ] )
 
       # Subsequent calls don't re-raise the warning
-      ycm.HandleFileParseRequest()
+      ycm.HandleFileParseResponse()
       post_vim_message.assert_has_exact_calls( [
         call( ERROR_TEXT, truncate = False )
       ] )
 
+      EmulateCurrentBufferChange()
       # But it does if a subsequent event raises again
       ycm.OnFileReadyToParse()
       ok_( ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
+      ycm.HandleFileParseResponse()
       post_vim_message.assert_has_exact_calls( [
         call( ERROR_TEXT, truncate = False ),
         call( ERROR_TEXT, truncate = False )
@@ -155,7 +157,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_NonNative_test(
   with MockArbitraryBuffer( 'javascript' ):
     with MockEventNotification( None, False ):
       ycm.OnFileReadyToParse()
-      ycm.HandleFileParseRequest()
+      ycm.HandleFileParseResponse()
       vim_command.assert_not_called()
 
 
@@ -167,7 +169,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_NonNative_test(
 def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
     ycm, ignore_extra_conf, load_extra_conf ):
 
-  # This test validates the behaviour of YouCompleteMe.HandleFileParseRequest
+  # This test validates the behaviour of YouCompleteMe.HandleFileParseResponse
   # in combination with YouCompleteMe.OnFileReadyToParse when the completer
   # raises the (special) UnknownExtraConf exception
 
@@ -187,7 +189,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
                   new_callable = ExtendedMock ) as present_dialog:
         ycm.OnFileReadyToParse()
         ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE ),
@@ -197,7 +199,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
         ] )
 
         # Subsequent calls don't re-raise the warning
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE )
@@ -206,10 +208,11 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
           call( FILE_NAME ),
         ] )
 
+        EmulateCurrentBufferChange()
         # But it does if a subsequent event raises again
         ycm.OnFileReadyToParse()
         ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE ),
@@ -224,9 +227,10 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
       with patch( 'ycm.vimsupport.PresentDialog',
                   return_value = 1,
                   new_callable = ExtendedMock ) as present_dialog:
+        EmulateCurrentBufferChange()
         ycm.OnFileReadyToParse()
         ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE ),
@@ -236,7 +240,7 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
         ] )
 
         # Subsequent calls don't re-raise the warning
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE )
@@ -245,10 +249,11 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
           call( FILE_NAME ),
         ] )
 
+        EmulateCurrentBufferChange()
         # But it does if a subsequent event raises again
         ycm.OnFileReadyToParse()
         ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+        ycm.HandleFileParseResponse()
 
         present_dialog.assert_has_exact_calls( [
           PresentDialog_Confirm_Call( MESSAGE ),
@@ -262,9 +267,12 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
 
 @YouCompleteMeInstance()
 def EventNotification_FileReadyToParse_Diagnostic_Error_Native_test( ycm ):
-  _Check_FileReadyToParse_Diagnostic_Error( ycm )
-  _Check_FileReadyToParse_Diagnostic_Warning( ycm )
-  _Check_FileReadyToParse_Diagnostic_Clean( ycm )
+  with MockArbitraryBuffer( 'cpp' ):
+    _Check_FileReadyToParse_Diagnostic_Error( ycm )
+    EmulateCurrentBufferChange()
+    _Check_FileReadyToParse_Diagnostic_Warning( ycm )
+    EmulateCurrentBufferChange()
+    _Check_FileReadyToParse_Diagnostic_Clean( ycm )
 
 
 @patch( 'vim.command' )
@@ -278,25 +286,24 @@ def _Check_FileReadyToParse_Diagnostic_Error( ycm, vim_command ):
     diagnostic = Diagnostic( [], start, extent, 'expected ;', 'ERROR' )
     return [ BuildDiagnosticData( diagnostic ) ]
 
-  with MockArbitraryBuffer( 'cpp' ):
-    with MockEventNotification( DiagnosticResponse ):
-      ycm.OnFileReadyToParse()
-      ok_( ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
-      vim_command.assert_has_calls( [
-        PlaceSign_Call( 1, 1, 1, True )
-      ] )
-      eq_( ycm.GetErrorCount(), 1 )
-      eq_( ycm.GetWarningCount(), 0 )
+  with MockEventNotification( DiagnosticResponse ):
+    ycm.OnFileReadyToParse()
+    ok_( ycm.FileParseRequestReady() )
+    ycm.HandleFileParseResponse()
+    vim_command.assert_has_calls( [
+      PlaceSign_Call( 1, 1, 1, True )
+    ] )
+    eq_( ycm.GetErrorCount(), 1 )
+    eq_( ycm.GetWarningCount(), 0 )
 
-      # Consequent calls to HandleFileParseRequest shouldn't mess with
-      # existing diagnostics, when there is no new parse request.
-      vim_command.reset_mock()
-      ok_( not ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
-      vim_command.assert_not_called()
-      eq_( ycm.GetErrorCount(), 1 )
-      eq_( ycm.GetWarningCount(), 0 )
+    # Consequent calls to HandleFileParseResponse shouldn't mess with
+    # existing diagnostics, when there is no new parse request.
+    vim_command.reset_mock()
+    ok_( ycm.FileParseRequestReady() )
+    ycm.HandleFileParseResponse()
+    vim_command.assert_not_called()
+    eq_( ycm.GetErrorCount(), 1 )
+    eq_( ycm.GetWarningCount(), 0 )
 
 
 @patch( 'vim.command' )
@@ -311,26 +318,25 @@ def _Check_FileReadyToParse_Diagnostic_Warning( ycm, vim_command ):
     diagnostic = Diagnostic( [], start, extent, 'cast', 'WARNING' )
     return [ BuildDiagnosticData( diagnostic ) ]
 
-  with MockArbitraryBuffer( 'cpp' ):
-    with MockEventNotification( DiagnosticResponse ):
-      ycm.OnFileReadyToParse()
-      ok_( ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
-      vim_command.assert_has_calls( [
-        PlaceSign_Call( 2, 2, 1, False ),
-        UnplaceSign_Call( 1, 1 )
-      ] )
-      eq_( ycm.GetErrorCount(), 0 )
-      eq_( ycm.GetWarningCount(), 1 )
+  with MockEventNotification( DiagnosticResponse ):
+    ycm.OnFileReadyToParse()
+    ok_( ycm.FileParseRequestReady() )
+    ycm.HandleFileParseResponse()
+    vim_command.assert_has_calls( [
+      PlaceSign_Call( 2, 2, 1, False ),
+      UnplaceSign_Call( 1, 1 )
+    ] )
+    eq_( ycm.GetErrorCount(), 0 )
+    eq_( ycm.GetWarningCount(), 1 )
 
-      # Consequent calls to HandleFileParseRequest shouldn't mess with
-      # existing diagnostics, when there is no new parse request.
-      vim_command.reset_mock()
-      ok_( not ycm.FileParseRequestReady() )
-      ycm.HandleFileParseRequest()
-      vim_command.assert_not_called()
-      eq_( ycm.GetErrorCount(), 0 )
-      eq_( ycm.GetWarningCount(), 1 )
+    # Consequent calls to HandleFileParseResponse shouldn't mess with
+    # existing diagnostics, when there is no new parse request.
+    vim_command.reset_mock()
+    ok_( ycm.FileParseRequestReady() )
+    ycm.HandleFileParseResponse()
+    vim_command.assert_not_called()
+    eq_( ycm.GetErrorCount(), 0 )
+    eq_( ycm.GetWarningCount(), 1 )
 
 
 @patch( 'vim.command' )
@@ -338,15 +344,14 @@ def _Check_FileReadyToParse_Diagnostic_Clean( ycm, vim_command ):
   # Tests Vim sign unplacement and error/warning count python API
   # when there are no errors/warnings left.
   # Should be called after _Check_FileReadyToParse_Diagnostic_Warning
-  with MockArbitraryBuffer( 'cpp' ):
-    with MockEventNotification( MagicMock( return_value = [] ) ):
-      ycm.OnFileReadyToParse()
-      ycm.HandleFileParseRequest()
-      vim_command.assert_has_calls( [
-        UnplaceSign_Call( 2, 1 )
-      ] )
-      eq_( ycm.GetErrorCount(), 0 )
-      eq_( ycm.GetWarningCount(), 0 )
+  with MockEventNotification( MagicMock( return_value = [] ) ):
+    ycm.OnFileReadyToParse()
+    ycm.HandleFileParseResponse()
+    vim_command.assert_has_calls( [
+      UnplaceSign_Call( 2, 1 )
+    ] )
+    eq_( ycm.GetErrorCount(), 0 )
+    eq_( ycm.GetWarningCount(), 0 )
 
 
 @patch( 'ycm.youcompleteme.YouCompleteMe._AddUltiSnipsDataIfNeeded' )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -150,6 +150,10 @@ def GetCurrentBufferNumber():
   return vim.current.buffer.number
 
 
+def GetBufferChangeTick( bufnr ):
+  return GetIntValue( u'getbufvar({0}, "changedtick")'.format( bufnr ) )
+
+
 def BufferIsVisible( buffer_number ):
   if buffer_number < 0:
     return False

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -36,6 +36,7 @@ from subprocess import PIPE
 from tempfile import NamedTemporaryFile
 from requests.exceptions import Timeout
 from ycm import base, paths, vimsupport
+from ycm.buffer import BufferDict
 from ycmd import utils
 from ycmd import server_utils
 from ycmd.request_wrap import RequestWrap
@@ -50,8 +51,7 @@ from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import ( CompletionRequest,
                                             ConvertCompletionDataToVimData )
 from ycm.client.omni_completion_request import OmniCompletionRequest
-from ycm.client.event_notification import ( SendEventNotificationAsync,
-                                            EventNotification )
+from ycm.client.event_notification import SendEventNotificationAsync
 from ycm.client.shutdown_request import SendShutdownRequest
 
 
@@ -116,10 +116,9 @@ class YouCompleteMe( object ):
     self._user_notified_about_crash = False
     self._diag_interface = DiagnosticInterface( user_options )
     self._omnicomp = OmniCompleter( user_options )
-    self._latest_file_parse_request = None
-    self._latest_file_parse_request_bufnr = 0
+    self._buffers = BufferDict()
+    self._buffer = None
     self._latest_completion_request = None
-    self._latest_diagnostics = []
     self._logger = logging.getLogger( 'ycm' )
     self._client_logfile = None
     self._server_stdout = None
@@ -134,6 +133,11 @@ class YouCompleteMe( object ):
       'cs': lambda self: self._OnCompleteDone_Csharp()
     }
     self._file_parse_ready_callbacks = []
+
+
+  def _GetCurrentBuffer( self ):
+    return self._buffers[ vimsupport.GetCurrentBufferNumber() ]
+
 
   def _SetupServer( self ):
     self._available_completers = {}
@@ -349,22 +353,30 @@ class YouCompleteMe( object ):
              self.NativeFiletypeCompletionAvailable() )
 
 
-  def OnFileReadyToParse( self ):
+  def OnFileReadyToParse( self, block = False ):
     if not self.IsServerAlive():
       self._NotifyUserIfServerCrashed()
       return
 
     self._omnicomp.OnFileReadyToParse( None )
 
-    extra_data = {}
-    self._AddTagsFilesIfNeeded( extra_data )
-    self._AddSyntaxDataIfNeeded( extra_data )
-    self._AddExtraConfDataIfNeeded( extra_data )
+    self._buffer = self._GetCurrentBuffer()
+    # Do nothing if previous parse request is not finished
+    # it will return 'already parsing' anyway.
+    if not self._buffer.FileParseRequestReady( block ):
+      return
 
-    self._latest_file_parse_request_bufnr = vimsupport.GetCurrentBufferNumber()
-    self._latest_file_parse_request = EventNotification(
-      'FileReadyToParse', extra_data = extra_data )
-    self._latest_file_parse_request.Start()
+    self.HandleFileParseResponse()
+
+    if self._buffer.NeedsReparse():
+      extra_data = {}
+      self._AddTagsFilesIfNeeded( extra_data )
+      self._AddSyntaxDataIfNeeded( extra_data )
+      self._AddExtraConfDataIfNeeded( extra_data )
+
+      self._buffer.SendParseRequest( extra_data )
+      if block:
+        self.HandleFileParseResponse()
 
 
   def OnBufferUnload( self, deleted_buffer_file ):
@@ -592,28 +604,27 @@ class YouCompleteMe( object ):
   def PopulateLocationListWithLatestDiagnostics( self ):
     # Do nothing if loc list is already populated by diag_interface
     if not self._user_options[ 'always_populate_location_list' ]:
-      self._diag_interface.PopulateLocationList( self._latest_diagnostics )
-    return bool( self._latest_diagnostics )
+      self._diag_interface.PopulateLocationList( self._buffer.Diagnostics() )
+    return bool( self._buffer.Diagnostics() )
 
 
   def UpdateDiagnosticInterface( self ):
-    self._diag_interface.UpdateWithNewDiagnostics( self._latest_diagnostics )
+    self._diag_interface.UpdateWithNewDiagnostics( self._buffer.Diagnostics() )
 
 
-  def FileParseRequestReady( self, block = False ):
-    return bool( self._latest_file_parse_request and
-                 ( block or self._latest_file_parse_request.Done() ) )
+  # For testing purposes
+  def FileParseRequestReady( self ):
+    return self._buffer.FileParseRequestReady()
 
 
-  def HandleFileParseRequest( self, block = False ):
-    # Order is important here:
-    # FileParseRequestReady has a low cost, while
+  def HandleFileParseResponse( self ):
+    if self._buffer.IsResponseHandled():
+      return
+
     # NativeFiletypeCompletionUsable is a blocking server request
-    if ( self.FileParseRequestReady( block ) and
-         self.NativeFiletypeCompletionUsable() ):
-
+    if self.NativeFiletypeCompletionUsable():
       if self.ShouldDisplayDiagnostics():
-        self._latest_diagnostics = self._latest_file_parse_request.Response()
+        self._buffer.UpdateDiagnostics()
         self.UpdateDiagnosticInterface()
       else:
         # YCM client has a hard-coded list of filetypes which are known
@@ -623,19 +634,11 @@ class YouCompleteMe( object ):
         # the _latest_file_parse_request for any exception or UnknownExtraConf
         # response, to allow the server to raise configuration warnings, etc.
         # to the user. We ignore any other supplied data.
-        self._latest_file_parse_request.Response()
+        self._buffer.GetResponse()
 
-      self.NotifyFileParseReady( self._latest_file_parse_request_bufnr )
-      # We set the file parse request to None because we want to prevent
-      # repeated issuing of the same warnings/errors/prompts. Setting this to
-      # None makes FileParseRequestReady return False until the next
-      # request is created.
-      #
-      # Note: it is the server's responsibility to determine the frequency of
-      # error/warning/prompts when receiving a FileReadyToParse event, but
-      # it our responsibility to ensure that we only apply the
-      # warning/error/prompt received once (for each event).
-      self._latest_file_parse_request = None
+      self.NotifyFileParseReady( self._buffer.number )
+
+    self._buffer.MarkResponseHandled()
 
 
   def ShowDetailedDiagnostic( self ):


### PR DESCRIPTION
This PR blocks new FileReadyToParse requests if there is already ongoing one, because new one will return "already parsing" result anyway.
Improvements:
 - Prevent server spamming.
 - Does not overwrite ongoing parse request, which allows to get intermediate info from it after parse is done.
 - Change parsed tick only when parse request will get going, rather then end up as "already parsing", allowing to know more precisely when parse is needed. (Fixes bug when adding compile error just after opening big TU does not show up until new change)
 - Fixes bug when calling YcmDiags on just opened big TU does not block.
 - Decreases number of unwanted/unnecessary FileRequestReady notifications, which improves DyeVim stability.
 - Moves some of the logic from VimL to python and simplifies it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davits/youcompleteme/1)
<!-- Reviewable:end -->
